### PR TITLE
Call link callback on mouse released, not mouse clicked

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -56,14 +56,14 @@ Headers:
 
 Indents: 
 On a new line, at the start of the line, add two spaces per indent.
-贩Indent level 1
-贩贩Indent level 2
+路路Indent level 1
+路路路路Indent level 2
 
 Unordered lists: 
 On a new line, at the start of the line, add two spaces, an asterisks and a space. 
 For nested lists, add two additional spaces in front of the asterisk per list level increment.
-贩*稶nordered List level 1
-贩贩*稶nordered List level 2
+路路*路Unordered List level 1
+路路路路*路Unordered List level 2
 
 Links:
 [link description](https://...)
@@ -556,7 +556,7 @@ namespace ImGui
                         }
                         if( ImGui::IsItemHovered() )
                         {
-                            if( ImGui::IsMouseClicked( 0 ) && mdConfig_.linkCallback && useLinkCallback )
+                            if( ImGui::IsMouseReleased( 0 ) && mdConfig_.linkCallback && useLinkCallback )
                             {
                                 mdConfig_.linkCallback( { markdown_ + link.text.start, link.text.size(), markdown_ + link.url.start, link.url.size(), mdConfig_.userData, true } );
                             }
@@ -629,7 +629,7 @@ namespace ImGui
 
         if(bHovered)
         {
-            if(ImGui::IsMouseClicked( 0 ) && mdConfig_.linkCallback)
+            if(ImGui::IsMouseReleased( 0 ) && mdConfig_.linkCallback)
             {
                 mdConfig_.linkCallback( { markdown_ + link_.text.start, link_.text.size(), markdown_ + link_.url.start, link_.url.size(), mdConfig_.userData, false } );
             }


### PR DESCRIPTION
Hi,

this pull request changes the moment, the link callback will be called.

With this pull request links are not going to be called, when the mouse went from `!down` to `down`, but when it went from `down` to `!down`.

Why:

In my application, I use links to switch windows within my application. (You can open windows from the user help, which uses markdown).
I do this using `ImGui::SetWindowFocus` which does not work as intended in a docking environment, when the links activate on mouse down (the window containing the markdown will steal the focus immediately back). 

Furthermore its what I as an user expect. (i.e. in Google Chrome links open on mouse up, not mouse down)

Thanks for imgui_markdown!

ClaasJG