### PR TITLE
Image Resize when available size.x > image width

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -230,6 +230,7 @@ namespace ImGui
     {
         bool                    isValid = false;                    // if true, will draw the image
         bool                    useLinkCallback = false;            // if true, linkCallback will be called when image is clicked
+        bool                    resizeIfNeeded = false;             // if true, will resize the image to fit in the current ImWindow
         ImTextureID             user_texture_id = 0;                // see ImGui::Image
         ImVec2                  size = ImVec2( 100.0f, 100.0f );    // see ImGui::Image
         ImVec2                  uv0 = ImVec2( 0, 0 );               // see ImGui::Image
@@ -587,7 +588,7 @@ namespace ImGui
                             {
                                 ImVec2 const contentSize = ImGui::GetContentRegionAvail();
                                 ImVec2 usedSize = imageData.size;
-                                if( usedSize.x > contentSize.x )
+                                if( imageData.resizeIfNeeded && usedSize.x > contentSize.x )
                                 {
                                     float const ratio = usedSize.y/usedSize.x;
                                     usedSize.x = contentSize.x;

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -585,7 +585,15 @@ namespace ImGui
                             useLinkCallback = imageData.useLinkCallback;
                             if( imageData.isValid )
                             {
-                                ImGui::Image( imageData.user_texture_id, imageData.size, imageData.uv0, imageData.uv1, imageData.tint_col, imageData.border_col );
+                                ImVec2 const contentSize = ImGui::GetContentRegionAvail();
+                                ImVec2 usedSize = imageData.size;
+                                if ( usedSize.x > contentSize.x )
+                                {
+                                    float const ratio = usedSize.y/usedSize.x;
+                                    usedSize.x = contentSize.x;
+                                    usedSize.y = contentSize.x*ratio;
+                                }
+                                ImGui::Image( imageData.user_texture_id, usedSize, imageData.uv0, imageData.uv1, imageData.tint_col, imageData.border_col );
                                 drawnImage = true;
                             }
                         }

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -587,7 +587,7 @@ namespace ImGui
                             {
                                 ImVec2 const contentSize = ImGui::GetContentRegionAvail();
                                 ImVec2 usedSize = imageData.size;
-                                if ( usedSize.x > contentSize.x )
+                                if( usedSize.x > contentSize.x )
                                 {
                                     float const ratio = usedSize.y/usedSize.x;
                                     usedSize.x = contentSize.x;


### PR DESCRIPTION
Resize when ImGui::GetContentRegionAvailWidth() < imageData.size.x with respect of image ratio.
![Xxqp7e86q0](https://user-images.githubusercontent.com/4236325/103183169-04179e00-48b1-11eb-842b-37b02ea6c51e.gif)
Tested to support image position on the line (not convicing).
```
float const imgPos = ImGui::GetCursorPosX();
contentSize.x -= imgPos;
```
TBD: support for:
```
![Alt](imgs/Image.png =250x50)
// And
![Alt](imgs/Image.png =250x)
```