### PR TITLE
Escaping symbols

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -667,21 +667,25 @@ namespace ImGui
                 }
             }
 
+            
 			switch (em.state)
 			{
 			case Emphasis::NONE:
-				if (c == '*' || c == '_') {
 
-					line.lineEnd = i;
-					RenderLine(markdown_, line, textRegion, mdConfig_);
-					ImGui::SameLine(0.0f, 0.0f);
-					line.lastRenderPosition = i;
-                    line.isEmphasis = true;
+				if (link.state == Link::NO_LINK) {
+					if (c == '*' || c == '_') {
 
-					em.state = Emphasis::LEFT;
-					em.sym = c;
-                    line.emphasisCount = 1;
-					continue;
+						line.lineEnd = i;
+						RenderLine(markdown_, line, textRegion, mdConfig_);
+						ImGui::SameLine(0.0f, 0.0f);
+						line.lastRenderPosition = i;
+						line.isEmphasis = true;
+
+						em.state = Emphasis::LEFT;
+						em.sym = c;
+						line.emphasisCount = 1;
+						continue;
+					}
 				}
 				break;
 			case Emphasis::LEFT:
@@ -690,7 +694,7 @@ namespace ImGui
 					continue;
 				} else {
 
-                    line.lastRenderPosition = i - 1;
+					line.lastRenderPosition = i - 1;
 					em.state = Emphasis::MIDDLE;
 				}
 				break;
@@ -707,16 +711,16 @@ namespace ImGui
 				} else if (i < em.end + line.emphasisCount) {
 					em.state = Emphasis::MIDDLE;
 				} else {
-                    
+
 					line.lineEnd = i - line.emphasisCount;
 					RenderLine(markdown_, line, textRegion, mdConfig_);
 
-                    line.isEmphasis = false;
+					line.isEmphasis = false;
 
 					ImGui::SameLine(0.0f, 0.0f);
-					line.lastRenderPosition = i-1;
+					line.lastRenderPosition = i - 1;
 
-                    em.state = Emphasis::NONE;
+					em.state = Emphasis::NONE;
 				}
 				break;
 			}
@@ -732,6 +736,7 @@ namespace ImGui
                     ImGui::Separator();
                     ImGui::SameLine(0.0f, 0.0f);
                     em.state = Emphasis::NONE;
+                    line.isEmphasis = false;
                 } else {
                     RenderLine(markdown_, line, textRegion, mdConfig_);
                 }
@@ -890,15 +895,17 @@ namespace ImGui
                 {
                     ImGui::PushFont( fmt.font );
                 }
-                ImGui::NewLine();
+               // ImGui::NewLine();
             }
             else
             {
                 if( fmt.separator )
                 {
                     ImGui::Separator();
+                } else {
+                    ImGui::NewLine();
                 }
-                ImGui::NewLine();
+                
                 if( fmt.font )
                 {
                     ImGui::PopFont();

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -424,6 +424,7 @@ namespace ImGui
         TextBlock text;
         TextBlock url;
         bool isImage = false;
+        int num_brackets_open = 0;
     };
 
 	struct Emphasis {
@@ -613,10 +614,13 @@ namespace ImGui
                 {
                     link.state = Link::HAS_SQUARE_BRACKETS_ROUND_BRACKET_OPEN;
                     link.url.start = i + 1;
+                    link.num_brackets_open = 1;
                 }
                 break;
             case Link::HAS_SQUARE_BRACKETS_ROUND_BRACKET_OPEN:
-                if( c == ')' )
+                if (c == '(')++link.num_brackets_open;
+                else if (c == ')')--link.num_brackets_open;
+                if(link.num_brackets_open==0)
                 {
                     // render previous line content
                     line.lineEnd = link.text.start - ( link.isImage ? 2 : 1 );
@@ -895,13 +899,18 @@ namespace ImGui
                 {
                     ImGui::PushFont( fmt.font );
                 }
-               // ImGui::NewLine();
+#ifndef IMGUI_MARKDOWN_LESS_NEWLINES
+                ImGui::NewLine();
+#endif
             }
             else
             {
                 if( fmt.separator )
                 {
                     ImGui::Separator();
+#ifndef IMGUI_MARKDOWN_LESS_NEWLINES
+                    ImGui::NewLine();
+#endif
                 } else {
                     ImGui::NewLine();
                 }


### PR DESCRIPTION
This patch adds support of
1. Emphasis:  * or _
2. Escape symbol:  '\\'
3. Horizontal Rules: *** or ___