### PR TITLE
Support square brackets in link text

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -441,6 +441,7 @@ namespace ImGui
         TextBlock text;
         TextBlock url;
         bool isImage = false;
+        int num_square_brackets_open = 0;
         int num_brackets_open = 0;
     };
 
@@ -602,6 +603,7 @@ namespace ImGui
                 {
                     link.state = Link::HAS_SQUARE_BRACKET_OPEN;
                     link.text.start = i + 1;
+                    link.num_square_brackets_open = 1;
                     if( i > 0 && markdown_[i - 1] == '!' )
                     {
                         link.isImage = true;
@@ -609,7 +611,15 @@ namespace ImGui
                 }
                 break;
             case Link::HAS_SQUARE_BRACKET_OPEN:
-                if( c == ']' )
+                if( c == '[' )
+                {
+                    ++link.num_square_brackets_open;
+                }
+                else if( c == ']' )
+                {
+                    --link.num_square_brackets_open;
+                }
+                if( link.num_square_brackets_open == 0 )
                 {
                     link.state = Link::HAS_SQUARE_BRACKETS;
                     link.text.stop = i;


### PR DESCRIPTION
Add support for nested square brackets in link text.

ex.

`[alice [at] example dot com](https://example.com)` previously parsed as:

```
TEXT: alice [at
LINK: https://example.com
```

This will now parse as:
```
TEXT: alice [at] example dot com
LINK: https://example.com
```