### PR TITLE
Fix for removal of GetContentRegionMax() in imgui 1.91.0

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -885,7 +885,7 @@ namespace ImGui
                 if( IsCharInsideWord( *endLine ) )
                 {
                     // see if we can do a better cut.
-                    float       widthNextLine = GetContentRegionMax().x;
+                    float       widthNextLine = widthLeft + GetCursorScreenPos().x - GetWindowPos().x; // was GetContentRegionMax().x on IMGUI_VERSION_NUM < 19099
                     const char* endNextLine = ImGui::GetFont()->CalcWordWrapPositionA( scale, text_, text_end_, widthNextLine );
                     if( endNextLine == text_end_ || ( endNextLine <= text_end_ && !IsCharInsideWord( *endNextLine ) ) )
                     {


### PR DESCRIPTION
In 1.91.0 wip i have obsoleted a few functions including `GetContentRegionMax()`:
https://github.com/ocornut/imgui/commit/b20f62b162e5f1e44748eb768f6b126a25ec29de

The reasoning being that those functions were very confusing/misleading and very error prone (\*), and I believe we can do everything with `GetCursorScreenPos()` and `GetContentRegionAvail()`.

Although the function still exists, if it removed when setting `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` in imconfig.h and will likely we completely removed in 2 years.

This trivial patch replaces it in a way that works for old and new versions of dear imgui. While replacing you can notice how weird the value of this function is (it was designed at a point in time were I expected to use more window-local-coordinates, but they always turned into a small disaster ^^).

----

(\*) Coincidentally, while removing the function I noticed that this is used incorrectly...
I added some debug rendering:
```cpp
float       widthNextLine = widthLeft + GetCursorScreenPos().x - GetWindowPos().x; // was GetContentRegionMax().x on IMGUI_VERSION_NUM < 19099

if (ImGui::GetIO().KeyShift)
    ImGui::GetForegroundDrawList()->AddLine(
        ImVec2(GetWindowPos().x, GetCursorScreenPos().y),
        ImVec2(GetWindowPos().x, GetCursorScreenPos().y) + ImVec2(widthNextLine, 0.0f), IM_COL32(0, 255, 255, 255));
```
![image](https://github.com/user-attachments/assets/90de2641-864d-4352-9574-ef2b1347191c)

Here's the starting position of the line doesn't matter much, it is meant to display "widthNextLine".
And you can see in this screenshot that it's using this value (which is roughly == the window width minus padding) to evaluate how the link could fit or be wrapped. But because we are inside a bulleted list we should likely use the width between the bullet and right-side of window, and not the width between left-side of window and right-side of window.

In my experience too many users used `GetContentRegionMax()`, `GetWindowContentRegionMin()`, `GetWindowContentRegionMax()` incorrectly, it's really easy to get confused, why is why I removed them. As a tip it's useful to display debug overlay to confirm position and width that are what you expect.