### PR TITLE
Add the text to the formatting callback

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -281,6 +281,8 @@ namespace ImGui
         int32_t                 level   = 0;                               // Set for headings: 1 for H1, 2 for H2 etc.
         bool                    itemHovered = false;                       // Currently only set for links when mouse hovered, only valid when start_ == false
         const MarkdownConfig*   config  = NULL;
+        const char*             text    = NULL;
+        int32_t                 textLength = 0;
     };
 
     typedef void                MarkdownLinkCallback( MarkdownLinkCallbackData data );
@@ -494,8 +496,10 @@ namespace ImGui
         {
             formatInfo.level = line_.headingCount;
             formatInfo.type = MarkdownFormatType::HEADING;
-            mdConfig_.formatCallback( formatInfo, true );
             const char* text = markdown_ + textStart + 1;
+            formatInfo.text = text;
+            formatInfo.textLength = textSize - 1;
+            mdConfig_.formatCallback( formatInfo, true );
             textRegion_.RenderTextWrapped( text, text + textSize - 1 );
         }
 		else if( line_.isEmphasis )         // render emphasis


### PR DESCRIPTION
We have the info available, it's probably useful for a few reasons.

In my case it was to add support for relative links (remember the offsets of headings so links can reference them).