### PR TITLE
callbacks: adjust formatting

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -285,8 +285,8 @@ namespace ImGui
         int32_t                 textLength = 0;
     };
 
-    typedef void                MarkdownLinkCallback( MarkdownLinkCallbackData data );
-    typedef void                MarkdownTooltipCallback( MarkdownTooltipCallbackData data );
+    typedef void                (MarkdownLinkCallback)( MarkdownLinkCallbackData data );
+    typedef void                (MarkdownTooltipCallback)( MarkdownTooltipCallbackData data );
 
     inline void defaultMarkdownTooltipCallback( MarkdownTooltipCallbackData data_ )
     {


### PR DESCRIPTION
Hi there
I'm a maintainer of https://github.com/AllenDang/cimgui-go which uses this project via https://github.com/gucio321/cimmarkdown.

Would you be so kind to add this tiny change to make my generator work correctly on the upstream repo (I'd not need to maintain my fork) :pray: Thank you in advance!

Added brackets around names of callbacks typedefs.

This is for compatibility with https://github.com/gucio321/cimmarkdown

IIRC there was a problem to distinguish between callbacks typedefs and something else (cant remember what exactly). If you wish I can make the research again and tell what exactly was the problem