### PR TITLE
Fix wrapping for line containing regular and formatted text

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -905,7 +905,7 @@ namespace ImGui
             #if IMGUI_VERSION_NUM >= 19197
                 const char* endNextLine = ImGui::GetFont()->CalcWordWrapPosition( fontSize, text_, text_end_, widthNextLine );
             #else
-                const char* endNextLine = ImGui::GetFont()->CalcWordWrapPositionA( scale, text_, text_end_, widthLeft );
+                const char* endNextLine = ImGui::GetFont()->CalcWordWrapPositionA( scale, text_, text_end_, widthNextLine );
             #endif
                 if( endNextLine == text_end_ || ( endNextLine <= text_end_ && !IsCharInsideWord( *endNextLine ) ) )
                 {
@@ -970,7 +970,7 @@ namespace ImGui
                     #if IMGUI_VERSION_NUM >= 19197
                         const char* endNextLine = ImGui::GetFont()->CalcWordWrapPosition( fontSize, text_, text_end_, widthNextLine );
                     #else
-                        const char* endNextLine = ImGui::GetFont()->CalcWordWrapPositionA( scale, text_, text_end_, widthLeft );
+                        const char* endNextLine = ImGui::GetFont()->CalcWordWrapPositionA( scale, text_, text_end_, widthNextLine );
                     #endif
                     if( endNextLine == text_end_ || ( endNextLine <= text_end_ && !IsCharInsideWord( *endNextLine ) ) )
                     {


### PR DESCRIPTION
Hello!

I noticed that the text wrapping doesn't work properly if a line contains combination of regular and formatted text.

<img width="399" height="121" alt="image" src="https://github.com/user-attachments/assets/86fe24bb-a020-431c-82ed-fe1f6a64c3c3" />

Implementing the same code used to fix #24 in the RenderTextWrapped method fixes the issue. I moved its definition below so as to have access to the IsCharInsideWord function. This is the result after:

<img width="398" height="121" alt="image" src="https://github.com/user-attachments/assets/1bf253b2-4356-4783-8d1a-6dfb5c348f65" />