### PR TITLE
Render image alt text as a link if image is not drawn

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -657,7 +657,7 @@ namespace ImGui
                         }
                         if( !drawnImage )
                         {
-                            ImGui::Text( "( Image %.*s not loaded )", link.url.size(), markdown_ + link.url.start );
+                            textRegion.RenderLinkTextWrapped( markdown_ + link.text.start, markdown_ + link.text.start + link.text.size(), link, markdown_, mdConfig_, &linkHoverStart, false );
                         }
                         if( ImGui::IsItemHovered() )
                         {


### PR DESCRIPTION
Hello again!

Currently, the 'Image not loaded' message is rendered if an image wasn't drawn. There are 2 issues with this:
- ImGui::Text is used, which doesn't wrap the text.
- The image alt text should be rendered as a link instead. If there is no alt text, nothing should be rendered. This is how GitHub Markdown works for example.

This PR renders the image alt text as a link if an image wasn't drawn.