### PR TITLE
Improved headings and more accurate line parsing

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -542,11 +542,6 @@ namespace ImGui
             // If we're at the beginning of the line, count any spaces
             if( line.isLeadingSpace )
             {
-                if( c == ' ' )
-                {
-                    ++line.leadSpaceCount;
-                    continue;
-                }
                 if ( (mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_DiscardExtraNewLines) ) // Discard LF and CRLF newlines by markdown spec
                 {
                     if ( c == '\n' )
@@ -562,6 +557,12 @@ namespace ImGui
                         i += 1;
                         continue;
                     }
+                }
+
+                if( c == ' ' )
+                {
+                    ++line.leadSpaceCount;
+                    continue;
                 }
                 else
                 {

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -519,6 +519,7 @@ namespace ImGui
         Link        link;
         Emphasis    em;
         TextRegion  textRegion;
+        int concurrentEmptyNewlines = 0;
 
         bool firstLine = true;
 
@@ -539,11 +540,13 @@ namespace ImGui
                 else if ( c == '\n' )
                 {
                     // Discard LF newlines by markdown spec
+                    concurrentEmptyNewlines++;
                     continue;
                 }
                 else if ( ( c == '\r' ) && ( (int)markdownLength_ > i + 1 ) && ( markdown_[i + 1] == '\n' ) )
                 {
                     // Discard CRLF newlines by markdown spec
+                    concurrentEmptyNewlines++;
                     i += 1;
                     continue;
                 }
@@ -806,6 +809,10 @@ namespace ImGui
                 }
                 else
                 {
+                    // In markdown spec, 2 or more consecutive newlines gets converted to a single blank line
+                    if (concurrentEmptyNewlines >= 2) {
+                        ImGui::NewLine();
+                    }
                     // render the line: multiline emphasis requires a complex implementation so not supporting
                     RenderLine( markdown_, line, textRegion, mdConfig_, firstLine );
                 }
@@ -824,6 +831,7 @@ namespace ImGui
                 link = Link();
 
                 firstLine = false;
+                concurrentEmptyNewlines = 0;
             }
         }
 

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -1127,7 +1127,7 @@ namespace ImGui
             }
             if (start_)
             {
-                if ( 0 == ( markdownFormatInfo_.config->formatFlags & ImGuiMarkdownFormatFlags_NoNewLineIfHeadingFirstLine ) || !markdownFormatInfo_.firstLine )
+                if ( 0 == ( markdownFormatInfo_.config->formatFlags & ImGuiMarkdownFormatFlags_NoNewLineIfHeadingFirstLine ) )
                 {
                     ImGui::NewLine();
                 }

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -520,6 +520,7 @@ namespace ImGui
         Emphasis    em;
         TextRegion  textRegion;
         int concurrentEmptyNewlines = 0;
+        bool appliedExtraNewline = false;
 
         bool firstLine = true;
 
@@ -599,6 +600,13 @@ namespace ImGui
                         }
                     }
                 }
+            }
+
+            // In markdown spec, 2 or more consecutive newlines gets converted to a single blank
+            // line The first newline is always digested so we check for 1 or more here
+            if (!appliedExtraNewline && !prevLine.isHeading && concurrentEmptyNewLines >= 1) {
+                ImGui::NewLine();
+                appliedExtraNewline = true;
             }
 
             // Test to see if we have a link
@@ -811,11 +819,6 @@ namespace ImGui
                 }
                 else
                 {
-                    // In markdown spec, 2 or more consecutive newlines gets converted to a single blank line
-                    // The first newline is always digested so we check for 1 or more here
-                    if (concurrentEmptyNewlines >= 1) {
-                        ImGui::NewLine();
-                    }
                     // render the line: multiline emphasis requires a complex implementation so not supporting
                     RenderLine( markdown_, line, textRegion, mdConfig_, firstLine );
                 }
@@ -835,6 +838,7 @@ namespace ImGui
 
                 firstLine = false;
                 concurrentEmptyNewlines = 0;
+                appliedExtraNewline = false;
             }
         }
 

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -536,6 +536,17 @@ namespace ImGui
                     ++line.leadSpaceCount;
                     continue;
                 }
+                else if ( c == '\n' )
+                {
+                    // Discard LF newlines by markdown spec
+                    continue;
+                }
+                else if ( ( c == '\r' ) && ( (int)markdownLength_ > i + 1 ) && ( markdown_[i + 1] == '\n' ) )
+                {
+                    // Discard CRLF newlines by markdown spec
+                    i += 1;
+                    continue;
+                }
                 else
                 {
                     line.isLeadingSpace = false;
@@ -1081,6 +1092,10 @@ namespace ImGui
             }
             if( start_ )
             {
+                if ( !markdownFormatInfo_.firstLine )
+                {
+                    ImGui::NewLine();
+                }
                 if( fmt.font  )
                 {
                     #ifdef IMGUI_HAS_TEXTURES // used to detect dynamic font capability: https://github.com/ocornut/imgui/issues/8465#issuecomment-2701570771
@@ -1089,20 +1104,21 @@ namespace ImGui
                         ImGui::PushFont( fmt.font );
                     #endif
                 }
-                if (!markdownFormatInfo_.firstLine) {
-                    ImGui::NewLine();
-                }
             }
             else
             {
                 if( fmt.separator )
                 {
+                    // In markdown the separator does not advance the cursor
+                    ImVec2 cursor = ImGui::GetCursorPos();
                     ImGui::Separator();
+                    ImGui::SetCursorPos( cursor );
                 }
                 if( fmt.font )
                 {
                     ImGui::PopFont();
                 }
+                ImGui::NewLine();
             }
             break;
         }

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -541,12 +541,14 @@ namespace ImGui
                 {
                     // Discard LF newlines by markdown spec
                     concurrentEmptyNewlines++;
+                    line.lineStart += 1;
                     continue;
                 }
                 else if ( ( c == '\r' ) && ( (int)markdownLength_ > i + 1 ) && ( markdown_[i + 1] == '\n' ) )
                 {
                     // Discard CRLF newlines by markdown spec
                     concurrentEmptyNewlines++;
+                    line.lineStart += 2;
                     i += 1;
                     continue;
                 }
@@ -810,7 +812,8 @@ namespace ImGui
                 else
                 {
                     // In markdown spec, 2 or more consecutive newlines gets converted to a single blank line
-                    if (concurrentEmptyNewlines >= 2) {
+                    // The first newline is always digested so we check for 1 or more here
+                    if (concurrentEmptyNewlines >= 1) {
                         ImGui::NewLine();
                     }
                     // render the line: multiline emphasis requires a complex implementation so not supporting

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -282,7 +282,7 @@ namespace ImGui
         const MarkdownConfig*   config  = NULL;
         const char*             text    = NULL;
         int32_t                 textLength = 0;
-        bool                    firstLine = false;                         // true if this line of text is not the first (used for headings)
+        bool                    firstLine = false;                         // true if this line of text is the first (used for headings)
     };
 
     typedef void                MarkdownLinkCallback( MarkdownLinkCallbackData data );

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -604,7 +604,7 @@ namespace ImGui
 
             // In markdown spec, 2 or more consecutive newlines gets converted to a single blank
             // line The first newline is always digested so we check for 1 or more here
-            if (!appliedExtraNewline && !prevLine.isHeading && concurrentEmptyNewLines >= 1) {
+            if (!appliedExtraNewline && !prevLine.isHeading && concurrentEmptyNewlines >= 1) {
                 ImGui::NewLine();
                 appliedExtraNewline = true;
             }

--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -547,20 +547,17 @@ namespace ImGui
                     ++line.leadSpaceCount;
                     continue;
                 }
-                else if ( c == '\n' )
+                if ( (mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_DiscardExtraNewLines) ) // Discard LF and CRLF newlines by markdown spec
                 {
-                    concurrentEmptyNewlines++;
-                    if ( (mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_DiscardExtraNewLines) ) // Discard LF newlines by markdown spec
+                    if ( c == '\n' )
                     {
+                        concurrentEmptyNewlines++;
                         line.lineStart += 1;
                         continue;
                     }
-                }
-                else if ( ( c == '\r' ) && ( (int)markdownLength_ > i + 1 ) && ( markdown_[i + 1] == '\n' ) )
-                {
-                    concurrentEmptyNewlines++;
-                    if ( (mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_DiscardExtraNewLines) ) // Discard CRLF newlines by markdown spec
+                    else if ( ( c == '\r' ) && ( (int)markdownLength_ > i + 1 ) && ( markdown_[i + 1] == '\n' ) )
                     {
+                        concurrentEmptyNewlines++;
                         line.lineStart += 2;
                         i += 1;
                         continue;


### PR DESCRIPTION
This PR aims to fundamentally improve the rendering of headers and overall vertical spacing within imgui_markdown, according to reasonable markdown specifications.

Notably, markdown discards isolate newlines when being rendered, but that was not implemented within imgui_markdown, causing fundamentally inaccurate rendering. This PR brings in that functionality and greatly improved the accuracy of markdown rendering in my testing.

The main focus of this PR, however, was the rendering of headers. By markdown specifications, if a header is the first line of the markdown file, it will not have preliminary padding applied. To support this, I have added a new field `firstLine` to `ImGui::MarkdownFormatInfo` which enables this functionality of headers to work. Additionally, the original implementation of header formatting in `ImGui::defaultMarkdownFormatCallback` was incorrect. After some adjustments, the spacing now matches that of GitHub's markdown renderer (within a margin of error, of course).

This is just the first of a few PRs I plan to bring to imgui_markdown to improve the rendering, as I am using this for my own ImGui application and have made some improvements to the formatting/rendering of markdown elements.