### PR TITLE
Rigorous unordered list detection and feature-complete indentation support

### DIFF
--- a/imgui_markdown.h
+++ b/imgui_markdown.h
@@ -512,9 +512,9 @@ namespace ImGui
         }
     }
 
-    inline Line* DetectTargetLineAsIndent( const Line& self, Line indentLines_[MarkdownConfig::INDENTSTACKSIZE], int indentLinesCount_, bool& is_deeply_nested )
+    inline Line* DetectTargetLineAsIndent( const Line& self, Line indentLines_[MarkdownConfig::INDENTSTACKSIZE], int indentLinesCount_, bool& isDeeplyNested )
     {
-        is_deeply_nested = false;
+        isDeeplyNested = false;
         if (indentLinesCount_ >= MarkdownConfig::INDENTSTACKSIZE)
         {
             return nullptr; // too deep nesting
@@ -530,7 +530,7 @@ namespace ImGui
                     int indentDiff = self.leadSpaceCount - listLine->leadSpaceCount;
                     if (indentDiff > 5) // Too many spaces, not a sub-list
                     {
-                        is_deeply_nested = true;
+                        isDeeplyNested = true;
                         return nullptr;
                     }
 
@@ -635,7 +635,8 @@ namespace ImGui
                     // Deeply nested text always acts as plain-text, regardless of characters found
                     if ( !isDeeplyNested )  // this is always false without ImGuiMarkdownFormatFlags_ExoticIndents
                     {
-                        const bool marksUnorderedListing = ( mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_IncludeAllListPrefixes ) ? ( c == '*' || c == '-' || c == '+' ) : ( c == '*' );
+                        bool marksUnorderedListing = ( mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_IncludeAllListPrefixes ) ? ( c == '*' || c == '-' || c == '+' ) : ( c == '*' );
+                        marksUnorderedListing &= ( (int)markdownLength_ > i + 1 ) && ( markdown_[ i + 1 ] == ' ' );
                         if ( mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_ExoticIndents )
                         {
                             if ( !targetIndentLine )
@@ -652,7 +653,7 @@ namespace ImGui
                             line.unorderedListChar = c;
                             ++i;
                             ++line.lastRenderPosition;
-                            if (mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_ExoticIndents)
+                            if ( mdConfig_.formatFlags & ImGuiMarkdownFormatFlags_ExoticIndents )
                             {
                                 // This is for unordered lists, rather than plain-text
                                 line.indentCount = targetIndentLine ? targetIndentLine->indentCount + 1 : 0;
@@ -942,6 +943,7 @@ namespace ImGui
 
                 line.lineStart = i + 1;
                 line.lastRenderPosition = i;
+                nextIndentStackCount = -1;
 
                 textRegion.ResetIndent();
 


### PR DESCRIPTION
This PR makes the detection of unordered lists match markdown spec (+,  -, * are all valid unordered list markers).

It also implements fully featured indentation according to markdown spec (GitHub etc), allowing for much more versatility and greater support of existing markdown files that likely don't match the original implementation of imgui_markdown.

As an example, I tested the formatting of a pretty messed up and complex markdown file to see that things worked as expected.
Given the following input (forgive the literal keyboard smashing):

       ## Fixes/Repairs
    
    - dwadw
        + fwefw
              * fe4wf
                                 *- fewf* 
            - kfeok
                  - r3r33r
            # fefef
        - sefsfe
    **FA WEF A FAWF**

    *fejoi*

******

The following render is created (GitHub on the left, imgui_markdown on the right):

<img width="450" height="363" alt="Screenshot 2025-12-11 183218" src="https://github.com/user-attachments/assets/aa7a8e2f-9bbc-4398-acc9-705f13debab4" />

******

For reference, this is how imgui_markdown renders this text on the main and dev branch:

<img width="419" height="410" alt="image" src="https://github.com/user-attachments/assets/50be8716-6ade-4d65-90be-8e819f2ffa8b" />

This is obviously incorrect in ways that are not close to the actual markdown specification. Before this PR, trying to render markdown files from repositories on GitHub very often breaks in these ways.

******

Notably the vertical spacing is a bit wonky. This is fixed by #41 which I implemented as well. This PR is currently a draft because it relies on some fixes that exist in #41, so there is going to be merge conflicts I will have to resolve once #41 is merged into the dev branch.